### PR TITLE
Perf/caching

### DIFF
--- a/api/blueprints/product.py
+++ b/api/blueprints/product.py
@@ -5,7 +5,8 @@ from sqlalchemy.orm import joinedload
 
 from ...database import db
 from ..decorators import token_required
-from ..models import Product, Category, Portion, Role
+from ..utils.redis_service import retrieve_products, store_products
+from ..models import Product, Category, Portion, Role, Portion_Size
 
 from ..utils.aws_s3 import s3_photo_upload
 
@@ -36,6 +37,15 @@ def product_index () :
         search = request.args.get('search')
         sort = request.args.get('sort')
 
+        cache_key = f'products:{page}:{category}:{search}:{sort}'
+
+        cached_products = retrieve_products(cache_key)
+
+        if cached_products :
+            return jsonify(
+                cached_products
+            ), 200
+
         # base query to build upon based on params 
         base_query = Product.query
 
@@ -46,16 +56,36 @@ def product_index () :
         if sort and sort != 'recommended':
             # to map sort options, utilizing text() in query
             sort_options = {
-                'priceAsc': 'price ASC',
-                'priceDesc': 'price DESC',
+                'priceAsc': 
+                    '''
+                        COALESCE(
+                            (SELECT price FROM portions
+                            WHERE portions.product_id = products.id
+                            AND portions.size = :whole
+                            LIMIT 1), 0
+                        ) ASC
+                    '''
+                ,
+                'priceDesc':
+                    '''
+                        COALESCE(
+                            (SELECT price FROM portions
+                            WHERE portions.product_id = products.id
+                            AND portions.size = :whole
+                            LIMIT 1), 0
+                        ) DESC
+                    '''
+                ,
                 'nameAsc': 'name ASC',
                 'nameDesc': 'name DESC',
             }
-            
+        
             sort_option = sort_options.get(sort)
 
-            if sort_option :
+            if sort_option and sort in ['priceAsc', 'priceDesc'] :
                 # adding sort to query
+                base_query = base_query.order_by(text(sort_option).params(whole = Portion_Size.WHOLE.value))
+            elif sort_option :
                 base_query = base_query.order_by(text(sort_option))
 
         if search :
@@ -76,12 +106,15 @@ def product_index () :
         if products.items :
             
             products_list = [ product.as_dict() for product in products.items ]
-            
-            return jsonify({
+            response = {
                 'products': products_list,
                 'totalPages': products.pages,
                 'currentPage': page
-            }), 200
+            }
+
+            store_products(cache_key, response)
+            
+            return jsonify(response), 200
         
         # otherwise, return empty array
         else :
@@ -326,6 +359,7 @@ def product_update_inventory () :
         return jsonify({
             'error': f'Error updating inventory: {str(error)}'
         }), 500
+
 
 @product_bp.route('/<int:id>', methods = ['GET'])
 def product_show (id) :

--- a/api/blueprints/user.py
+++ b/api/blueprints/user.py
@@ -3,7 +3,7 @@ import redis
 import jwt
 
 from ...database import db
-from ..utils.redis_service import store_token, is_token_blacklisted
+from ..utils.redis_service import cache_token, is_token_blacklisted
 from ..utils.token import generate_jwt, decode_jwt, get_time_until_jwt_expire
 from ..utils.set_auth_cookies import set_tokens_in_cookies
 from ..decorators import token_required
@@ -122,7 +122,7 @@ def logout () :
         ttl = int(get_time_until_jwt_expire(refresh_token)) + 300
 
         if ttl > 0 :
-            store_token(refresh_token, ttl)
+            cache_token(refresh_token, ttl)
     
     except redis.RedisError as re :
         current_app.logger.error(f'Redis error: {str(re)}')
@@ -215,7 +215,7 @@ def refresh_authentication_tokens () :
         ttl = int(get_time_until_jwt_expire(token)) + 300
 
         if ttl > 0 :
-            store_token(token, ttl)
+            cache_token(token, ttl)
         
         access_token = generate_jwt(id, payload.get('role'), 15)
         refresh_token = generate_jwt(id, payload.get('role'), 7 * 24 * 60)

--- a/api/models/__init__.py
+++ b/api/models/__init__.py
@@ -1,4 +1,5 @@
 from .portion import Portion
+from .portion import Portion_Size
 from .product import Product
 from .product import Category
 from .user import User

--- a/api/utils/redis_service.py
+++ b/api/utils/redis_service.py
@@ -1,9 +1,22 @@
 import os
+import json
 
 from cryptography.fernet import Fernet
 from ...redis_config import get_redis_client
 
 fernet = Fernet(os.getenv('FERNET_KEY').encode())
+
+def retrieve_products (key) :
+    redis_client = get_redis_client()
+    cached_products = redis_client.get(key)
+    return json.loads(cached_products) if cached_products else None
+
+def store_products (key, response) :
+    redis_client = get_redis_client()
+    
+    # expiration set for 24 hours
+    redis_client.setex(key, 86400, json.dumps(response))
+
 
 def encrypt_token (token) :
     return fernet.encrypt(token.encode()).decode()

--- a/api/utils/redis_service.py
+++ b/api/utils/redis_service.py
@@ -6,7 +6,7 @@ from ...redis_config import get_redis_client
 
 fernet = Fernet(os.getenv('FERNET_KEY').encode())
 
-def need_product_bucket () :
+def need_product_cache_bucket () :
     '''
     Checks if any keys with 'all_products' exists in cache using scan.
     Indicates whether a new cache of all the products needs to be created.
@@ -45,7 +45,13 @@ def cache_products (products) :
 
         pipe.execute()
 
-def get_filtered_products (key) :
+def get_product_cache (id) :
+    redis_client = get_redis_client()
+    product = redis_client.get(f'all_products:{id}')
+
+    return json.loads(product) if product else None
+
+def get_filtered_products_cache (key) :
     '''
     Retrieves a filtered list of products from cache based on provided filter parameters (indicated in key).
     

--- a/api/utils/redis_service.py
+++ b/api/utils/redis_service.py
@@ -6,16 +6,103 @@ from ...redis_config import get_redis_client
 
 fernet = Fernet(os.getenv('FERNET_KEY').encode())
 
-def retrieve_products (key) :
-    redis_client = get_redis_client()
-    cached_products = redis_client.get(key)
-    return json.loads(cached_products) if cached_products else None
+def need_product_bucket () :
+    '''
+    Checks if any keys with 'all_products' exists in cache using scan.
+    Indicates whether a new cache of all the products needs to be created.
 
-def store_products (key, response) :
+    Returns :
+        bool : True is no 'all_products*' keys are found, False otherwise.
+    '''
+    redis_client = get_redis_client()
+
+    while True :
+        cursor, keys = redis_client.scan(cursor = 0, match = 'all_products*', count = 100)
+
+        # indicates that a key was found
+        if keys :
+            return False
+        
+        # indicates scan is finished
+        if cursor == 0 :
+            break
+
+    return True
+
+def cache_products (products) :
+    '''
+    Caches a list of products, storing each product as a JSON string with the key format of 'all_products:product.id'.
+    Sets the expiration for each cache entry to 1 hour.
+
+    Args :
+        products (list) : list of product objects from database to be cached.
+    '''
     redis_client = get_redis_client()
     
-    # expiration set for 24 hours
-    redis_client.setex(key, 86400, json.dumps(response))
+    with redis_client.pipeline() as pipe :
+        for product in products :
+            pipe.set(f'all_products:{product.id}', json.dumps(product.as_dict()), ex = 3600)
+
+        pipe.execute()
+
+def get_filtered_products (key) :
+    '''
+    Retrieves a filtered list of products from cache based on provided filter parameters (indicated in key).
+    
+    Gets list of product ids and pagination metadata (needed for the response) from cache using key and retrieves
+    the product data from the 'all_products*' cache.
+
+    Args :
+        key (str) : cache key for retrieving filtered products, indicates what page, sort and filter.
+
+    Returns :
+        dict : dictionary containing list of products and pagination metadata
+        None : if no product ids or metadata found in cache from given key.
+    '''
+    redis_client = get_redis_client()
+
+    product_ids = redis_client.get(key)
+    metadata = redis_client.get(f'{key}:metadata')
+
+    products = []
+
+    if product_ids and metadata :
+        for id in json.loads(product_ids) :
+            product = redis_client.get(f'product:{id}')
+            if product :
+                products.append(json.loads(product))
+        
+        return {
+            'products': products,
+            'totalPages': json.loads(metadata).get('totalPages'),
+            'currentPage': json.loads(metadata).get('currentPage')
+        } if products else None
+    
+    return None
+
+def cache_filtered_products (key, response) :
+    '''
+    Caches the results of a filtered product query.
+
+    Stores list of product ids and pagination metadata under given key.
+
+    Args :
+        key (str) : cache key for storing filtered products, indicates what page, sort and filter.
+        response (dict) : dictionary containing list of products and pagination metadata.
+    '''
+    redis_client = get_redis_client()
+    product_ids = [product['id'] for product in response['products']]
+    metadata = {
+        'totalPages': response['totalPages'],
+        'currentPage': response['currentPage']
+    }
+
+    with redis_client.pipeline() as pipe :
+        pipe.set(key, json.dumps(product_ids))
+        pipe.set(f'{key}:metadata', json.dumps(metadata))
+
+        pipe.execute()
+
 
 
 def encrypt_token (token) :
@@ -24,7 +111,7 @@ def encrypt_token (token) :
 def decrypt_token(encrypted_token) :
     return fernet.decrypt(encrypted_token).decode()
 
-def store_token (token, ttl) :
+def cache_token (token, ttl) :
     redis_client = get_redis_client()
 
     redis_client.sadd('blacklist:tokens', encrypt_token(token))


### PR DESCRIPTION
Adds products to redis cache.

Product Controller -->
- index
     - checks and caches all products if needed
     - checks cache for specific filter results
     - stores specific filter results from db into cache
     - fixes priceASC and priceDESC sorting options to account for moving pricing to product.portions
- show
     - checks cache for product to bypass querying db if available

Utilities -->
- redis_service
      - `need_product_cache_bucket`, determines if products need to be caches by scanning for key matches to 'all_products' pattern
      - `cache_products`, caches each product under format of `'all_products:{product_id}': product_data`
      - `get_product_cache`, returns a single product with given id
      - `get_filtered_products_cache`, checks cache for a specific filter and retrieves each product from cache using the id
      - `cache_filtered_products`, caches specific filter results under format of `filter:products:**params: list_of_product_ids`
