### PR TITLE
implements global fixed window rate limiter

### DIFF
--- a/config.py
+++ b/config.py
@@ -6,6 +6,8 @@ class Config :
     STRIPE_API_KEY = os.getenv('STRIPE_SECRET_KEY')
     WEBHOOK_SECRET = os.getenv('WEBHOOK_SECRET')
     REDIS_URL = os.getenv('REDIS_URL')
+    MAX_REQUESTS = 60
+    RATE_LIMIT_WINDOW = 60
 
 class DevelopmentConfig(Config):
     DEBUG = True


### PR DESCRIPTION
implements global fixed window rate limiter based on client IP address using redis cache for storage

Config --> 
- adds `MAX_REQUEST` and `RATE_LIMIT_WINDOW` values for centralization

App -->
- uses `@app.before_request` decorator to manage rate limit logic
      - retrieves user's ip address and performs lookup in redis 
           - if found, returns 429 error if requests exceed limit
           - else, stores info in redis